### PR TITLE
Fix for datacite.resourcetype and _export from CISTI.UAL examples

### DIFF
--- a/app/controllers/concerns/doiable.rb
+++ b/app/controllers/concerns/doiable.rb
@@ -105,6 +105,7 @@ module Doiable
 
       author = options[:author].to_s.split(";").map { |a| { "name" => a.strip }}
       
+      # https://github.com/datacite/lupo/blob/62b8ae4069be3418f8312265f015db5827eed2e8/app/controllers/dois_controller.rb#L414-L464
       attributes = {
         "url" => options[:url],
         "xml" => xml,
@@ -112,7 +113,7 @@ module Doiable
         "title" => options[:title],
         "publisher" => options[:publisher],
         "published" => options[:published],
-        "resource_type_general" => options[:resource_type_general],
+        "resource-type-subtype" => options[:resource_type],
         "source" => "ez",
         "event" => event,
         "reason" => reason }.compact

--- a/app/controllers/concerns/doiable.rb
+++ b/app/controllers/concerns/doiable.rb
@@ -19,6 +19,7 @@ module Doiable
 
       status = STATES[attributes["state"]] || "public"
       status = [status, attributes["reason"]].join(" | ") if status == "unavailable" && attributes["reason"].present?
+      export_status = "no" unless status == "public"
 
       if options[:profile] == :datacite
         metadata = attributes["xml"].present? ? Base64.decode64(attributes["xml"]) : nil
@@ -31,7 +32,7 @@ module Doiable
         options[:profile] => metadata,
         "_profile" => options[:profile],
         "_datacenter" => response.dig("data", "relationships", "client", "data", "id").upcase,
-        "_export" => "yes",
+        "_export" => export_status || "yes",
         "_created" => Time.parse(attributes["created"]).to_i,
         "_updated" => Time.parse(attributes["updated"]).to_i,
         "_status" => status

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -196,8 +196,7 @@ class DoisController < ApplicationController
 
   def safe_params
     # custom URL decoding because there is also ANVL encoding
-    data = request.raw_post.gsub(/%20/, " ").gsub(/%22/, "\"").gsub(/%3C/, "<").gsub(/%3E/, ">").gsub(/%7B/, "{").gsub(/%7D/, "}").gsub(/%0A(_profile|_status|_target|_number|datacite|schema_org|ris|bibtex)/, "\n\\1").from_anvl
-
+    data = request.raw_post.gsub(/%20/, " ").gsub(/%22/, "\"").gsub(/%3C/, "<").gsub(/%3E/, ">").gsub(/%7B/, "{").gsub(/%7D/, "}").gsub(/%0A(_profile|_status|_target|_export|_number|datacite|schema_org|ris|bibtex)/, "\n\\1").from_anvl
     params.permit(:id, :_target, :_export, :_profile, :_status, :_number, :datacite, :bibtex, :ris, :schema_org, :citeproc).merge!(data)
   end
 

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -50,13 +50,8 @@ class DoisController < ApplicationController
       username: @username,
       password: @password }
 
-    options = options.merge(
-      author: decode_param(safe_params["datacite.creator"]),
-      title: decode_param(safe_params["datacite.title"]),
-      publisher: decode_param(safe_params["datacite.publisher"]),
-      published: decode_param(safe_params["datacite.publicationyear"]),
-      resource_type_general: decode_param(safe_params["datacite.resourcetype"])) if @profile.to_s == "datacite"
-
+    options = datacite_options(options) if @profile.to_s == "datacite"
+    
     response = DoisController.post_doi(doi, options)
 
     if [200, 201].include?(response.status)
@@ -90,12 +85,7 @@ class DoisController < ApplicationController
       username: @username,
       password: @password }.compact
 
-    options = options.merge(
-      author: decode_param(safe_params["datacite.creator"]),
-      title: decode_param(safe_params["datacite.title"]),
-      publisher: decode_param(safe_params["datacite.publisher"]),
-      published: decode_param(safe_params["datacite.publicationyear"]),
-      resource_type_general: decode_param(safe_params["datacite.resourcetype"])) if @profile.to_s == "datacite"
+    options = datacite_options(options) if @profile.to_s == "datacite"
 
     response = DoisController.post_doi(doi, options)
 
@@ -127,12 +117,7 @@ class DoisController < ApplicationController
       username: @username,
       password: @password }.compact
 
-    options = options.merge(
-      author: decode_param(safe_params["datacite.creator"]),
-      title: decode_param(safe_params["datacite.title"]),
-      publisher: decode_param(safe_params["datacite.publisher"]),
-      published: decode_param(safe_params["datacite.publicationyear"]),
-      resource_type_general: decode_param(safe_params["datacite.resourcetype"])) if @profile.to_s == "datacite"
+    options = datacite_options(options) if @profile.to_s == "datacite"
 
     response = DoisController.put_doi(@doi, options)
 
@@ -206,5 +191,17 @@ class DoisController < ApplicationController
     report.add_tab(:metadata, {
       metadata: URI.escape(safe_params[@profile])
     })
+  end
+  
+  def datacite_options(options)
+    resource_type_general, resource_type = decode_param(safe_params["datacite.resourcetype"])&.split('/')
+    options = options.merge(
+      author: decode_param(safe_params["datacite.creator"]),
+      title: decode_param(safe_params["datacite.title"]),
+      publisher: decode_param(safe_params["datacite.publisher"]),
+      published: decode_param(safe_params["datacite.publicationyear"]),
+      resource_type_general: resource_type_general,
+      resource_type: resource_type
+    ) 
   end
 end

--- a/spec/apis/user_examples_spec.rb
+++ b/spec/apis/user_examples_spec.rb
@@ -244,4 +244,81 @@ describe "user examples", :type => :api, vcr: true, :order => :defined do
       expect(doc.at_css("identifier").content).to eq("10.5072/4H3J-WR25")
     end
   end
+  
+  context "ual" do
+    let(:doi) { "10.21967/fk2-qscw-y487" }
+    
+    # see spec/fixtures/files/ual-update.txt#4 
+    # datacite.resourcetype: Text/Book
+    # This should be valid according to https://ezid.cdlib.org/doc/apidoc.html#profile-datacite
+    # 
+    # > The general type and, optionally, specific type of the data. The general type must be one of the controlled vocabulary terms defined in the DataCite Metadata Scheme:
+    # > ...
+    # > Specific types are unconstrained. If a specific type is given, it must be separated from the general type by a forward slash ("/")
+    # 
+    # It doesn't look like this is being parsed appropriately before being sent on to https://api.test.datacite.org/
+    # ```
+    # {
+    #   "data": {
+    #     "attributes": {
+    #       "resource_type_general": "Text/Book"
+    #     },
+    #     "relationships": {
+    #       "resource-type": {
+    #         "data": {
+    #           "type": "resource-types",
+    #           "id": "text/book"
+    #         }
+    #       }
+    #     }
+    #   }
+    # }
+    # ```
+    # so the response is 422
+    # with the error message 'found unpermitted parameter: :resource_type_general'
+    # more details in spec/files/vcr_cassettes/user_examples/ual/update_title_change.yml
+    it "update title change" do
+      str = File.read(file_fixture('ual-update.txt')).from_anvl
+      params = str.to_anvl
+      post "/id/doi:#{doi}", params, headers
+      expect(last_response.status).to eq(200)
+      response = last_response.body.from_anvl
+      expect(response["success"]).to eq("doi:10.21967/fk2-qscw-y487")
+      doc = Nokogiri::XML(response["datacite"], nil, 'UTF-8', &:noblanks)
+      expect(doc.at_css("identifier").content).to eq("10.21967/fk2-qscw-y487")
+      expect(doc.at_css("title").content).to eq("Different Title")
+    end
+    
+    # The following two tests are similar
+    # see spec/fixtures/files/ual-remove.txt#2 
+    # _export: no
+    # https://support.datacite.org/v1.1/reference#modify-doi references Internal Metadata
+    # which I assume is https://ezid.cdlib.org/doc/apidoc.html#internal-metadata and includes `_export`
+    # From this failing test and https://github.com/datacite/cheetoh/blob/master/app/controllers/dois_controller.rb#L197-L210
+    # it looks like _export is not considered
+    # more details in spec/files/vcr_cassettes/user_examples/ual/update_for_removal.yml
+    it "update for removal" do
+      str = File.read(file_fixture('ual-remove.txt')).from_anvl
+      params = str.to_anvl
+      post "/id/doi:#{doi}", params, headers
+      expect(last_response.status).to eq(200)
+      response = last_response.body.from_anvl
+      expect(response["success"]).to eq("doi:10.21967/fk2-qscw-y487")
+      expect(response["_status"]).to eq("unavailable | withdrawn")
+      expect(response["_export"]).to eq("no")
+    end
+    
+    it "update for being made private" do
+      str = File.read(file_fixture('ual-private.txt')).from_anvl
+      params = str.to_anvl
+      post "/id/doi:#{doi}", params, headers
+      expect(last_response.status).to eq(200)
+      response = last_response.body.from_anvl
+      expect(response["success"]).to eq("doi:10.21967/fk2-qscw-y487")
+      expect(response["_target"]).to eq(str[:_target])
+      expect(response["_status"]).to eq("unavailable | not publicly released")
+      expect(response["_export"]).to eq("no")
+    end
+    
+  end
 end

--- a/spec/apis/user_examples_spec.rb
+++ b/spec/apis/user_examples_spec.rb
@@ -285,7 +285,7 @@ describe "user examples", :type => :api, vcr: true, :order => :defined do
       response = last_response.body.from_anvl
       expect(response["success"]).to eq("doi:10.21967/fk2-qscw-y487")
       doc = Nokogiri::XML(response["datacite"], nil, 'UTF-8', &:noblanks)
-      expect(doc.at_css("identifier").content).to eq("10.21967/fk2-qscw-y487")
+      expect(doc.at_css("identifier").content).to eq("10.21967/FK2-QSCW-Y487")
       expect(doc.at_css("title").content).to eq("Different Title")
     end
     

--- a/spec/fixtures/files/ual-mint.txt
+++ b/spec/fixtures/files/ual-mint.txt
@@ -1,5 +1,0 @@
-_status: public
-  _profile: datacite
-  _target: http://localhost/items/e9b3b7d3-046b-4d13-bb79-1deacb22ca3c
-  _export: yes
-  datacite: <?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"><identifier identifierType="DOI"></identifier><creators><creator><creatorName>Joe Blow</creatorName></creator></creators><titles><title>Test Title</title></titles><publisher>University of Alberta Libraries</publisher><publicationYear>2017</publicationYear><resourceType resourceTypeGeneral="Text">Text/Book</resourceType><descriptions><description descriptionType="Abstract"></description></descriptions></resource>%0A

--- a/spec/fixtures/files/ual-mint.txt
+++ b/spec/fixtures/files/ual-mint.txt
@@ -1,0 +1,5 @@
+_status: public
+  _profile: datacite
+  _target: http://localhost/items/e9b3b7d3-046b-4d13-bb79-1deacb22ca3c
+  _export: yes
+  datacite: <?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"><identifier identifierType="DOI"></identifier><creators><creator><creatorName>Joe Blow</creatorName></creator></creators><titles><title>Test Title</title></titles><publisher>University of Alberta Libraries</publisher><publicationYear>2017</publicationYear><resourceType resourceTypeGeneral="Text">Text/Book</resourceType><descriptions><description descriptionType="Abstract"></description></descriptions></resource>%0A

--- a/spec/fixtures/files/ual-private.txt
+++ b/spec/fixtures/files/ual-private.txt
@@ -1,0 +1,7 @@
+datacite.creator: Joe Blow
+datacite.publisher: University of Alberta Libraries
+datacite.publicationyear: 2017
+datacite.title: Different Title
+_target: http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717
+_export: no
+_status: unavailable | not publicly released

--- a/spec/fixtures/files/ual-remove.txt
+++ b/spec/fixtures/files/ual-remove.txt
@@ -1,0 +1,2 @@
+_status: unavailable | withdrawn
+_export: no

--- a/spec/fixtures/files/ual-update.txt
+++ b/spec/fixtures/files/ual-update.txt
@@ -1,0 +1,8 @@
+datacite.creator: Joe Blow
+datacite.publisher: University of Alberta Libraries
+datacite.publicationyear: 2017
+datacite.resourcetype: Text/Book
+datacite.title: Different Title
+_target: http://localhost/items/9e15f53d-9e52-40b9-ab0f-307616b21e2d
+_status: public
+_export: yes

--- a/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_being_made_private.yml
+++ b/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_being_made_private.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.test.datacite.org/dois/10.21967/fk2-qscw-y487
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717\n_export:
+        no","author":[{"name":"Joe Blow"}],"title":"Different Title","publisher":"University
+        of Alberta Libraries","published":"2017","source":"ez","event":"hide","reason":"not
+        publicly released"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}}}}}'
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.1.1; +https://github.com/datacite/maremma)
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Authorization:
+      - Basic <MDS_TOKEN>
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 21:10:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - cisti.ual
+      X-Request-Id:
+      - 6d49012a-9125-469a-95d9-6437a4aab138
+      Etag:
+      - W/"0f1d9c68a29b83506c674f1c3d4cbde6"
+      X-Runtime:
+      - '0.115116'
+      X-Powered-By:
+      - Phusion Passenger 5.3.7
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.7
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717\n_export:
+        no","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"name":"Joe Blow"}],"title":"Different
+        Title","publisher":"University of Alberta Libraries","resource-type-subtype":"Text/Book","description":null,"version":null,"metadata-version":6,"schema-version":"http://datacite.org/schema/kernel-4","reason":"not
+        publicly released","source":"ez","state":"registered","is-active":false,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-14T21:10:03.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPlRleHQvQm9vazwvcmVzb3VyY2VUeXBlPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTc8L2RhdGU+CiAgPC9kYXRlcz4KICA8dmVyc2lvbi8+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ii8+CiAgPC9kZXNjcmlwdGlvbnM+CjwvcmVzb3VyY2U+Cg==","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-14T21:10:03Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
+        of Alberta Libraries","symbol":"CISTI.UAL","year":2018,"contact-name":"Peter
+        Binkley","contact-email":"peter.binkley@ualberta.ca","domains":"*","url":null,"created":"2018-11-02T20:52:32.000Z","updated":"2018-11-02T21:19:04.000Z","is-active":true,"has-password":true},"relationships":{"provider":{"data":{"id":"cisti","type":"providers"}},"prefixes":{"data":[{"id":"10.21967","type":"prefixes"}]}}},{"id":"text","type":"resource-types","attributes":{"title":"Text","updated":"2016-09-21T00:00:00Z"},"relationships":{}}]}'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 21:10:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_being_made_private.yml
+++ b/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_being_made_private.yml
@@ -5,9 +5,8 @@ http_interactions:
     uri: https://api.test.datacite.org/dois/10.21967/fk2-qscw-y487
     body:
       encoding: UTF-8
-      string: '{"data":{"type":"dois","attributes":{"url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717\n_export:
-        no","author":[{"name":"Joe Blow"}],"title":"Different Title","publisher":"University
-        of Alberta Libraries","published":"2017","source":"ez","event":"hide","reason":"not
+      string: '{"data":{"type":"dois","attributes":{"url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717","author":[{"name":"Joe
+        Blow"}],"title":"Different Title","publisher":"University of Alberta Libraries","published":"2017","source":"ez","event":"hide","reason":"not
         publicly released"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}}}}}'
     headers:
       User-Agent:
@@ -24,7 +23,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 14 Nov 2018 21:10:03 GMT
+      - Thu, 15 Nov 2018 04:13:31 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
@@ -35,26 +34,25 @@ http_interactions:
       - max-age=0, private, must-revalidate
       Vary:
       - Accept-Encoding, Origin
+      Etag:
+      - W/"0eece46346dd1a11360f23f0a72bcb26"
+      X-Runtime:
+      - '0.084143'
       X-Credential-Username:
       - cisti.ual
       X-Request-Id:
-      - 6d49012a-9125-469a-95d9-6437a4aab138
-      Etag:
-      - W/"0f1d9c68a29b83506c674f1c3d4cbde6"
-      X-Runtime:
-      - '0.115116'
+      - 95f3acc7-8d60-438a-816c-5ff9d61b0a85
       X-Powered-By:
       - Phusion Passenger 5.3.7
       Server:
       - nginx/1.14.0 + Phusion Passenger 5.3.7
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717\n_export:
-        no","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"name":"Joe Blow"}],"title":"Different
-        Title","publisher":"University of Alberta Libraries","resource-type-subtype":"Text/Book","description":null,"version":null,"metadata-version":6,"schema-version":"http://datacite.org/schema/kernel-4","reason":"not
-        publicly released","source":"ez","state":"registered","is-active":false,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-14T21:10:03.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPlRleHQvQm9vazwvcmVzb3VyY2VUeXBlPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTc8L2RhdGU+CiAgPC9kYXRlcz4KICA8dmVyc2lvbi8+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ii8+CiAgPC9kZXNjcmlwdGlvbnM+CjwvcmVzb3VyY2U+Cg==","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-14T21:10:03Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
+      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"name":"Joe
+        Blow"}],"title":"Different Title","publisher":"University of Alberta Libraries","resource-type-subtype":"Text/Book","description":null,"version":null,"metadata-version":7,"schema-version":"http://datacite.org/schema/kernel-4","reason":"not
+        publicly released","source":"ez","state":"registered","is-active":false,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-15T04:13:31.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPlRleHQvQm9vazwvcmVzb3VyY2VUeXBlPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTc8L2RhdGU+CiAgPC9kYXRlcz4KICA8dmVyc2lvbi8+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ii8+CiAgPC9kZXNjcmlwdGlvbnM+CjwvcmVzb3VyY2U+Cg==","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-15T04:13:31Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
         of Alberta Libraries","symbol":"CISTI.UAL","year":2018,"contact-name":"Peter
         Binkley","contact-email":"peter.binkley@ualberta.ca","domains":"*","url":null,"created":"2018-11-02T20:52:32.000Z","updated":"2018-11-02T21:19:04.000Z","is-active":true,"has-password":true},"relationships":{"provider":{"data":{"id":"cisti","type":"providers"}},"prefixes":{"data":[{"id":"10.21967","type":"prefixes"}]}}},{"id":"text","type":"resource-types","attributes":{"title":"Text","updated":"2016-09-21T00:00:00Z"},"relationships":{}}]}'
     http_version: 
-  recorded_at: Wed, 14 Nov 2018 21:10:03 GMT
+  recorded_at: Thu, 15 Nov 2018 04:13:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_removal.yml
+++ b/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_removal.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.test.datacite.org/dois/10.21967/fk2-qscw-y487
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"author":[],"source":"ez","event":"hide","reason":"withdrawn\n_export:
+        no"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}}}}}'
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.1.1; +https://github.com/datacite/maremma)
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Authorization:
+      - Basic <MDS_TOKEN>
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 22:43:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - cisti.ual
+      X-Request-Id:
+      - 5a791475-08fa-4be5-8679-abafeba73f1a
+      Etag:
+      - W/"3b13d24dc3d3e352a9495d206590eab7"
+      X-Runtime:
+      - '0.114132'
+      X-Powered-By:
+      - Phusion Passenger 5.3.7
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.7
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717\n_export:
+        no","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"type":"Person","name":"Joe
+        Blow","givenName":"Joe","familyName":"Blow"}],"title":"Different Title","publisher":"University
+        of Alberta Libraries","resource-type-subtype":"Text/Book","description":null,"version":null,"metadata-version":6,"schema-version":"http://datacite.org/schema/kernel-4","reason":"withdrawn\n_export:
+        no","source":"ez","state":"registered","is-active":false,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-14T22:43:02.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPlRleHQvQm9vazwvcmVzb3VyY2VUeXBlPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTc8L2RhdGU+CiAgPC9kYXRlcz4KICA8dmVyc2lvbi8+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ii8+CiAgPC9kZXNjcmlwdGlvbnM+CjwvcmVzb3VyY2U+Cg==","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-14T22:43:02Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
+        of Alberta Libraries","symbol":"CISTI.UAL","year":2018,"contact-name":"Peter
+        Binkley","contact-email":"peter.binkley@ualberta.ca","domains":"*","url":null,"created":"2018-11-02T20:52:32.000Z","updated":"2018-11-02T21:19:04.000Z","is-active":true,"has-password":true},"relationships":{"provider":{"data":{"id":"cisti","type":"providers"}},"prefixes":{"data":[{"id":"10.21967","type":"prefixes"}]}}},{"id":"text","type":"resource-types","attributes":{"title":"Text","updated":"2016-09-21T00:00:00Z"},"relationships":{}}]}'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 22:43:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_removal.yml
+++ b/spec/fixtures/vcr_cassettes/user_examples/ual/update_for_removal.yml
@@ -5,8 +5,7 @@ http_interactions:
     uri: https://api.test.datacite.org/dois/10.21967/fk2-qscw-y487
     body:
       encoding: UTF-8
-      string: '{"data":{"type":"dois","attributes":{"author":[],"source":"ez","event":"hide","reason":"withdrawn\n_export:
-        no"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}}}}}'
+      string: '{"data":{"type":"dois","attributes":{"author":[],"source":"ez","event":"hide","reason":"withdrawn"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}}}}}'
     headers:
       User-Agent:
       - Mozilla/5.0 (compatible; Maremma/4.1.1; +https://github.com/datacite/maremma)
@@ -22,7 +21,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 14 Nov 2018 22:43:03 GMT
+      - Thu, 15 Nov 2018 04:13:31 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
@@ -33,27 +32,25 @@ http_interactions:
       - max-age=0, private, must-revalidate
       Vary:
       - Accept-Encoding, Origin
+      Etag:
+      - W/"aaa9dcf73d49ca070d66b976afc060fa"
+      X-Runtime:
+      - '0.100233'
       X-Credential-Username:
       - cisti.ual
       X-Request-Id:
-      - 5a791475-08fa-4be5-8679-abafeba73f1a
-      Etag:
-      - W/"3b13d24dc3d3e352a9495d206590eab7"
-      X-Runtime:
-      - '0.114132'
+      - fb7ad8f6-0c7d-4424-916e-5badedb51d14
       X-Powered-By:
       - Phusion Passenger 5.3.7
       Server:
       - nginx/1.14.0 + Phusion Passenger 5.3.7
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717\n_export:
-        no","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"type":"Person","name":"Joe
+      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/e58cb0fd-cdee-4139-9ea4-488269e86717","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"type":"Person","name":"Joe
         Blow","givenName":"Joe","familyName":"Blow"}],"title":"Different Title","publisher":"University
-        of Alberta Libraries","resource-type-subtype":"Text/Book","description":null,"version":null,"metadata-version":6,"schema-version":"http://datacite.org/schema/kernel-4","reason":"withdrawn\n_export:
-        no","source":"ez","state":"registered","is-active":false,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-14T22:43:02.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPlRleHQvQm9vazwvcmVzb3VyY2VUeXBlPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTc8L2RhdGU+CiAgPC9kYXRlcz4KICA8dmVyc2lvbi8+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ii8+CiAgPC9kZXNjcmlwdGlvbnM+CjwvcmVzb3VyY2U+Cg==","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-14T22:43:02Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
+        of Alberta Libraries","resource-type-subtype":"Text/Book","description":null,"version":null,"metadata-version":7,"schema-version":"http://datacite.org/schema/kernel-4","reason":"withdrawn","source":"ez","state":"registered","is-active":false,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-15T04:13:31.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPlRleHQvQm9vazwvcmVzb3VyY2VUeXBlPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTc8L2RhdGU+CiAgPC9kYXRlcz4KICA8dmVyc2lvbi8+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ii8+CiAgPC9kZXNjcmlwdGlvbnM+CjwvcmVzb3VyY2U+Cg==","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-15T04:13:31Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
         of Alberta Libraries","symbol":"CISTI.UAL","year":2018,"contact-name":"Peter
         Binkley","contact-email":"peter.binkley@ualberta.ca","domains":"*","url":null,"created":"2018-11-02T20:52:32.000Z","updated":"2018-11-02T21:19:04.000Z","is-active":true,"has-password":true},"relationships":{"provider":{"data":{"id":"cisti","type":"providers"}},"prefixes":{"data":[{"id":"10.21967","type":"prefixes"}]}}},{"id":"text","type":"resource-types","attributes":{"title":"Text","updated":"2016-09-21T00:00:00Z"},"relationships":{}}]}'
     http_version: 
-  recorded_at: Wed, 14 Nov 2018 22:43:03 GMT
+  recorded_at: Thu, 15 Nov 2018 04:13:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/user_examples/ual/update_title_change.yml
+++ b/spec/fixtures/vcr_cassettes/user_examples/ual/update_title_change.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"type":"dois","attributes":{"url":"http://localhost/items/9e15f53d-9e52-40b9-ab0f-307616b21e2d","author":[{"name":"Joe
-        Blow"}],"title":"Different Title","publisher":"University of Alberta Libraries","published":"2017","resource_type_general":"Text/Book","source":"ez","event":"publish"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}},"resource-type":{"data":{"type":"resource-types","id":"text/book"}}}}}'
+        Blow"}],"title":"Different Title","publisher":"University of Alberta Libraries","published":"2017","resource-type-subtype":"Book","source":"ez","event":"publish"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}},"resource-type":{"data":{"type":"resource-types","id":"text"}}}}}'
     headers:
       User-Agent:
       - Mozilla/5.0 (compatible; Maremma/4.1.1; +https://github.com/datacite/maremma)
@@ -18,32 +18,40 @@ http_interactions:
       - Basic <MDS_TOKEN>
   response:
     status:
-      code: 422
+      code: 200
       message: ''
     headers:
       Date:
-      - Wed, 14 Nov 2018 22:15:17 GMT
+      - Thu, 15 Nov 2018 06:06:26 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
       Status:
-      - 422 Unprocessable Entity
+      - 200 OK
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Vary:
       - Accept-Encoding, Origin
+      X-Credential-Username:
+      - cisti.ual
       X-Request-Id:
-      - edcf5489-bd60-46c2-9c2e-077bb7dbb78e
+      - 8c75b852-c8c5-4550-8dd2-27e3dbdaa7b5
+      Etag:
+      - W/"f5942803de5a2180791d5ca7c83e23f3"
       X-Runtime:
-      - '0.050587'
+      - '0.219124'
       X-Powered-By:
       - Phusion Passenger 5.3.7
       Server:
       - nginx/1.14.0 + Phusion Passenger 5.3.7
     body:
       encoding: ASCII-8BIT
-      string: '{"errors":[{"status":"422","title":"found unpermitted parameter: :resource_type_general"}]}'
+      string: '{"data":{"id":"10.21967/fk2-qscw-y487","type":"dois","attributes":{"doi":"10.21967/fk2-qscw-y487","identifier":"https://handle.test.datacite.org/10.21967/fk2-qscw-y487","url":"http://localhost/items/9e15f53d-9e52-40b9-ab0f-307616b21e2d","prefix":"10.21967","suffix":"fk2-qscw-y487","author":[{"name":"Joe
+        Blow"}],"title":"Different Title","publisher":"University of Alberta Libraries","resource-type-subtype":"Book","description":null,"version":null,"metadata-version":9,"schema-version":"http://datacite.org/schema/kernel-4","reason":"not
+        publicly released","source":"ez","state":"findable","is-active":true,"landing-page":{"status":null,"content-type":null,"checked":null,"result":null},"published":"2017","created":"2018-11-14T20:38:41.000Z","registered":"2018-11-14T20:38:43.000Z","updated":"2018-11-15T06:06:25.000Z","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjE5NjcvRksyLVFTQ1ctWTQ4NzwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPkpvZSBCbG93PC9jcmVhdG9yTmFtZT4KICAgIDwvY3JlYXRvcj4KICA8L2NyZWF0b3JzPgogIDx0aXRsZXM+CiAgICA8dGl0bGU+RGlmZmVyZW50IFRpdGxlPC90aXRsZT4KICA8L3RpdGxlcz4KICA8cHVibGlzaGVyPlVuaXZlcnNpdHkgb2YgQWxiZXJ0YSBMaWJyYXJpZXM8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTc8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IlRleHQiPkJvb2s8L3Jlc291cmNlVHlwZT4KICA8ZGF0ZXM+CiAgICA8ZGF0ZSBkYXRlVHlwZT0iSXNzdWVkIj4yMDE3PC9kYXRlPgogIDwvZGF0ZXM+CiAgPHZlcnNpb24vPgogIDxkZXNjcmlwdGlvbnM+CiAgICA8ZGVzY3JpcHRpb24gZGVzY3JpcHRpb25UeXBlPSJBYnN0cmFjdCIvPgogIDwvZGVzY3JpcHRpb25zPgo8L3Jlc291cmNlPgo=","cache-key":"dois/10.21967/fk2-qscw-y487-2018-11-15T06:06:25Z"},"relationships":{"client":{"data":{"id":"cisti.ual","type":"clients"}},"resource-type":{"data":{"id":"text","type":"resource_types"}},"media":{"data":[]}}},"included":[{"id":"cisti.ual","type":"clients","attributes":{"name":"University
+        of Alberta Libraries","symbol":"CISTI.UAL","year":2018,"contact-name":"Peter
+        Binkley","contact-email":"peter.binkley@ualberta.ca","domains":"*","url":null,"created":"2018-11-02T20:52:32.000Z","updated":"2018-11-02T21:19:04.000Z","is-active":true,"has-password":true},"relationships":{"provider":{"data":{"id":"cisti","type":"providers"}},"prefixes":{"data":[{"id":"10.21967","type":"prefixes"}]}}},{"id":"text","type":"resource-types","attributes":{"title":"Text","updated":"2016-09-21T00:00:00Z"},"relationships":{}}]}'
     http_version: 
-  recorded_at: Wed, 14 Nov 2018 22:15:17 GMT
+  recorded_at: Thu, 15 Nov 2018 06:06:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/user_examples/ual/update_title_change.yml
+++ b/spec/fixtures/vcr_cassettes/user_examples/ual/update_title_change.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.test.datacite.org/dois/10.21967/fk2-qscw-y487
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"url":"http://localhost/items/9e15f53d-9e52-40b9-ab0f-307616b21e2d","author":[{"name":"Joe
+        Blow"}],"title":"Different Title","publisher":"University of Alberta Libraries","published":"2017","resource_type_general":"Text/Book","source":"ez","event":"publish"},"relationships":{"client":{"data":{"type":"clients","id":"CISTI.UAL"}},"resource-type":{"data":{"type":"resource-types","id":"text/book"}}}}}'
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.1.1; +https://github.com/datacite/maremma)
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Authorization:
+      - Basic <MDS_TOKEN>
+  response:
+    status:
+      code: 422
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 22:15:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 422 Unprocessable Entity
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept-Encoding, Origin
+      X-Request-Id:
+      - edcf5489-bd60-46c2-9c2e-077bb7dbb78e
+      X-Runtime:
+      - '0.050587'
+      X-Powered-By:
+      - Phusion Passenger 5.3.7
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.7
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"status":"422","title":"found unpermitted parameter: :resource_type_general"}]}'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 22:15:17 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
I'm testing the Datacite EZ API in anticipation of porting our application from https://ezid.cdlib.org.  https://github.com/ualbertalib/jupiter/issues/911 Our application has existing tests for minting, updating metadata, and making unavailable.

I'm using [ezid-client](https://github.com/duke-libraries/ezid-client) ruby gem but the unexpected behaviour I've encountered is also present sending HTTP requests with curl. This led me to finding cheetoh!

The first thing I found was a problem with `datacite.resourcetype: Text/Book`
This should be valid according to https://ezid.cdlib.org/doc/apidoc.html#profile-datacite

> The general type and, optionally, specific type of the data. The general type must be one of the controlled vocabulary terms defined in the DataCite Metadata Scheme:
> ...
> Specific types are unconstrained. If a specific type is given, it must be separated from the general type by a forward slash ("/")
 
Here is part of what is sent to https://api.test.datacite.org/
 ```
 {
   "data": {
     "attributes": {
       "resource_type_general": "Text/Book"
     },
     "relationships": {
       "resource-type": {
         "data": {
           "type": "resource-types",
           "id": "text/book"
         }
       }
     }
   }
 }
 ```
so the response is 422 with the error message 'found unpermitted parameter: :resource_type_general'

The second thing I found in error was `_export: no`
I followed a trail of documentation. https://support.datacite.org/v1.1/reference#modify-doi references 'Internal Metadata' which I assume is https://ezid.cdlib.org/doc/apidoc.html#internal-metadata (but just wasn't copied over) and includes `_export`
From the `update for removal` and `update for being made private` failing tests I've included here and https://github.com/datacite/cheetoh/blob/master/app/controllers/dois_controller.rb#L197-L210
it looks like _export is not considered. It appears to me that _export should be `no` unless the doi is in the `findable`/`public` state, but I'm not familiar with the intricacies of these terms.